### PR TITLE
Add --enable-yjit config option, test for success

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,12 +100,14 @@ jobs:
     - run: chmod 755 $HOME # https://github.com/actions/virtual-environments/issues/267
     - run: mkdir -p ~/.rubies
     - run: ./autogen.sh
-    - run: ./configure --prefix=$HOME/.rubies/ruby-${{ matrix.name }} --enable-shared --disable-install-doc
+    - run: ./configure --prefix=$HOME/.rubies/ruby-${{ matrix.name }} --enable-shared --disable-install-doc --enable-yjit
       if: startsWith(matrix.os, 'ubuntu')
-    - run: ./configure --prefix=$HOME/.rubies/ruby-${{ matrix.name }} --enable-shared --disable-install-doc --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline)
+    - run: ./configure --prefix=$HOME/.rubies/ruby-${{ matrix.name }} --enable-shared --disable-install-doc --enable-yjit --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline)
       if: startsWith(matrix.os, 'macos')
     - run: make -j4
     - run: make install
+
+    - run: ruby --yjit -e 'exit RubyVM::YJIT.enabled?'
 
     - name: Create archive
       run: tar czf ruby-${{ matrix.name }}-${{ steps.platform.outputs.platform }}.tar.gz -C ~/.rubies ruby-${{ matrix.name }}


### PR DESCRIPTION
Previously YJIT was included in the Ruby head build.  It is now an option.

See ruby/ruby@f90549cd3851

Both rustc and cargo are installed on the Actions Ubuntu images.

JFYI, using locally, and Puma also runs a job with YJIT enabled.  Currently shows a message

`/home/runner/.rubies/ruby-head/bin/ruby: warning: Ruby was built without YJIT support`

previously we saw:

`ruby 3.2.0dev (2022-04-15T18:31:37Z master 059e389ffc) +YJIT [x86_64-linux]`