### PR TITLE
Add cli test for all bin files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       release_id: ${{ steps.create_release.outputs.id }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
       if: github.event_name == 'schedule'
@@ -69,7 +69,7 @@ jobs:
         sudo /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
 
     - name: Clone Ruby
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ruby/ruby
 
@@ -103,7 +103,7 @@ jobs:
     - run: make test-all TESTS="-j4"
 
     - run: echo "$HOME/.rubies/ruby-${{ matrix.name }}/bin" >> $GITHUB_PATH
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: test_files
     - name: CLI Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,15 +106,13 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: test_files
+    - name: CLI Test
+      run: ruby test_files/cli_test.rb
     - run: mv test_files/Gemfile .
-    - run: ruby --version
     - run: ruby -e 'pp RbConfig::CONFIG'
     - run: ruby --yjit -e 'exit RubyVM::YJIT.enabled?'
-    - run: gem --version
-    - run: rake --version
     - run: ruby -ropen-uri -e 'puts URI.send(:open, "https://rubygems.org/") { |f| f.read(1024) }'
     - run: gem install json:2.2.0 --no-document
-    - run: bundle --version
     - run: bundle install
     - run: bundle exec rake --version
     - name: Subprocess test

--- a/cli_test.rb
+++ b/cli_test.rb
@@ -1,0 +1,63 @@
+require 'rbconfig'
+
+module CLITest
+  class << self
+    BIN_DIR = RbConfig::CONFIG['bindir']
+
+    DASH = "\u2500".dup.force_encoding 'utf-8'
+
+    def chk_cli(cmd, regex)
+      cmd_str = cmd[/\A[^ ]+/].ljust(10)
+      if File.exist? "#{BIN_DIR}/#{cmd_str}".strip
+        require 'open3'
+        ret = ''.dup
+        Open3.popen3(cmd) {|stdin, stdout, stderr, wait_thr|
+          ret = stdout.read.strip
+        }
+        if ret[regex]
+          "#{cmd_str}✅   #{$1}"
+        else
+          @error += 1
+          "#{cmd_str}❌   version?"
+        end
+      else
+        @error += 1
+        "#{cmd_str}❌   missing binstub"
+      end
+    rescue => e
+      @error += 1
+      "#{cmd_str}❌   #{e.class}"
+    end
+
+    def run
+      re_version = '(\d{1,2}\.\d{1,2}\.\d{1,2}(\.[a-z0-9.]+)?)'
+      @error = 0
+      puts "\n#{DASH * 5} CLI Test #{DASH * 17}"
+      puts chk_cli("bundle -v",      /\ABundler version #{re_version}/)
+      puts chk_cli("gem --version",  /\A#{re_version}/)
+      puts chk_cli("irb --version",  /\Airb +#{re_version}/)
+      puts chk_cli("racc --version", /\Aracc version #{re_version}/)
+      puts chk_cli("rake -V", /\Arake, version #{re_version}/)
+      puts chk_cli("rbs -v" , /\Arbs #{re_version}/)
+      puts chk_cli("rdbg -v", /\Ardbg #{re_version}/)
+      puts chk_cli("rdoc -v", /\A#{re_version}/)
+      puts ''
+
+      cli_desc =  %x[ruby -v].strip
+      if cli_desc == RUBY_DESCRIPTION
+        puts cli_desc, ''
+      else
+        puts "'ruby -v' doesn't match RUBY_DESCRIPTION\n" \
+             "#{cli_desc}  (ruby -v)\n" \
+             "#{RUBY_DESCRIPTION}  (RUBY_DESCRIPTION)", ''
+        @error += 1
+      end
+
+      unless @error.zero?
+        puts "bad exit"
+        exit 1
+      end
+    end
+  end
+end
+CLITest.run


### PR DESCRIPTION
First commit adds a script (cli_test.sh) that tests all bin files.

Second commit updates actions/checkout to v3 (from v2)

Current builds are 'broken', but are passing.  The rbs gem is not included.  See https://github.com/ruby/ruby/pull/7114.

Can't easily run the PR in my fork, but the script runs correctly locally.