### PR TITLE
Actions - add workflow_dispatch, allowing maintainer forced CI runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     - '*'
   schedule:
   - cron: '0 19 * * *'
+  workflow_dispatch:
+
 jobs:
   release:
     name: Create GitHub Release


### PR DESCRIPTION
When ruby/ruby has commits that cause collateral damage, they may be reverted or updated.

This PR should allow maintainers to force a CI run when needed.