### PR TITLE
Use OpenSSL 3 on macOS, as ruby/ruby does

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
     - run: ./autogen.sh
     - run: ./configure --prefix=$HOME/.rubies/ruby-${{ matrix.name }} --enable-shared --disable-install-doc --enable-yjit
       if: startsWith(matrix.os, 'ubuntu')
-    - run: ./configure --prefix=$HOME/.rubies/ruby-${{ matrix.name }} --enable-shared --disable-install-doc --enable-yjit --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline)
+    - run: ./configure --prefix=$HOME/.rubies/ruby-${{ matrix.name }} --enable-shared --disable-install-doc --enable-yjit --with-openssl-dir=$(brew --prefix openssl@3) --with-readline-dir=$(brew --prefix readline)
       if: startsWith(matrix.os, 'macos')
     - run: make -j4
     - run: make install


### PR DESCRIPTION
See https://github.com/ruby/setup-ruby/issues/631.

Currently, ruby/ruby macOS CI uses OpenSSL 3, and the macOS release builds for setup-ruby of Ruby 3.1, 3.2, and 3.3 use OpenSSL 3.