### PR TITLE
Add 3.4-asan builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,8 @@ jobs:
     needs: [prepare]
     if: needs.prepare.outputs.should_build == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -227,6 +229,8 @@ jobs:
   publish:
     name: Publish Release
     needs: [release, build]
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Publish Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,26 @@ jobs:
     outputs:
       should_build: ${{ steps.check_commit.outputs.result }}
       commit: ${{ steps.latest_commit.outputs.commit }}
+      commit_3_4_asan: ${{ steps.latest_commit_3_4_asan.outputs.commit }}
     steps:
     - name: Clone ruby
       uses: actions/checkout@v4
       with:
         repository: ruby/ruby
         path: ruby
+        fetch-tags: true
+        fetch-depth: 0 # Workaround for https://github.com/actions/checkout/issues/1781
     - name: Set latest_commit
       id: latest_commit
       working-directory: ruby
       run: echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+    - name: Set latest commit (3.4-asan)
+      id: latest_commit_3_4_asan
+      working-directory: ruby
+      run: |
+        LATEST_TAG=$(git tag --list | grep -E "v3_4_[0-9]+$" | sort -V | tail -n1)
+        git checkout "$LATEST_TAG"
+        echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
     - name: Check if latest commit already built
       uses: actions/github-script@v7
@@ -30,11 +40,13 @@ jobs:
       with:
         script: |
           const latestDevCommit = "${{ steps.latest_commit.outputs.commit }}"
+          const latest34Asan = "${{ steps.latest_commit_3_4_asan.outputs.commit }}"
           const { owner, repo } = context.repo
           let { data: release } = await github.rest.repos.getLatestRelease({ owner, repo })
           const latestReleaseCommit = release.body.split('@')[1]
           console.log(`Latest release commit: ${latestReleaseCommit}`)
           console.log(`Latest ruby commit: ${latestDevCommit}`)
+          console.log(`Latest 3.4-asan: ${latest34Asan}`)
           if (latestReleaseCommit === latestDevCommit) {
             return 'false'
           } else {
@@ -82,6 +94,7 @@ jobs:
         name: [ head, debug ]
         include:
           - { os: ubuntu-24.04, name: asan }
+          - { os: ubuntu-24.04, name: 3.4-asan }
     runs-on: ${{ matrix.os }}
     steps:
     - name: Clone ruby
@@ -89,6 +102,13 @@ jobs:
       with:
         repository: ruby/ruby
         ref: ${{ needs.prepare.outputs.commit }}
+      if: matrix.name != '3.4-asan'
+    - name: Clone ruby (3.4-asan)
+      uses: actions/checkout@v4
+      with:
+        repository: ruby/ruby
+        ref: ${{ needs.prepare.outputs.commit_3_4_asan }}
+      if: matrix.name == '3.4-asan'
     - name: Clone ruby-dev-builder
       uses: actions/checkout@v4
       with:
@@ -163,7 +183,7 @@ jobs:
         # Make the test timeouts more generous too (ASAN is slower)
         echo "RUBY_TEST_TIMEOUT_SCALE=5" >> $GITHUB_ENV
         echo "SYNTAX_SUGGEST_TIMEOUT=600" >> $GITHUB_ENV
-      if: matrix.name == 'asan'
+      if: matrix.name == 'asan' || matrix.name == '3.4-asan'
 
     # Build
     - run: mkdir -p ~/.rubies


### PR DESCRIPTION
**What does this PR do?**

This PR introduces a new "3.4-asan" build, based on the existing asan builds, but just pointed at whatever's the latest tag in the 3.4 series.

**Motivation:**

The intention of "3.4-stable" is to provide the latest up-to-date stable Ruby, so that we can reliably use it as a breaking CI step.

As discussed in https://github.com/ruby/setup-ruby/issues/682, the current ruby-asan builds are a bit of a "sharp edge" when used in CI because they may break due to changes that are completely unrelated to asan.

Building asan rubies is a bit awkward still, as e.g. ruby-build and other version managers don't have support for it, and it requires very modern versions of specific system tools (e.g. clang).

**Additional Notes:**

After some back-and-forth, the changes are reasonably minimal.

In particular, I decided to not touch the logic that determines weather there's a more recent commit to build or not. This does mean that if ruby master sees no commits, but there's a new 3.4 stable release, this won't be picked up immediately; and it also means that if there's a new master commit and no change to the 3.4 branch we still rebuild 3.4-asan.

My thinking is that the extra complexity to individually take care of the caching for both branches is not worth the trouble vs doing some extra rebuilds for 3.4-asan.

Let me know if you're not convinced, and I can change that.

**How to test the change?**

I've built this in the downstream fork, and manually downloaded the resulting Ruby and it seems to be in good shape and with asan working fine.

* Successful run: https://github.com/DataDog/ruby-dev-builder/actions/runs/12827351740
* Resulting builds: https://github.com/DataDog/ruby-dev-builder/releases/tag/v20250117.103455