### PR TITLE
Add 3.4-asan builds, try 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,14 +46,14 @@ jobs:
       with:
         script: |
           const latestDevCommit = "${{ steps.latest_commit.outputs.commit }}"
-          const latest34Asan = "${{ steps.latest_commit_3_4_asan.outputs.commit }}"
+          const latest34ASan = "${{ steps.latest_commit_3_4_asan.outputs.commit }}"
           const { owner, repo } = context.repo
           let { data: release } = await github.rest.repos.getLatestRelease({ owner, repo })
           const firstLine = release.body.split('\n')[0]
           const latestReleaseCommit = firstLine.split('@')[1]
           console.log(`Latest release commit: ${latestReleaseCommit}`)
           console.log(`Latest ruby commit: ${latestDevCommit}`)
-          console.log(`Latest 3.4-asan: ${latest34Asan}`)
+          console.log(`Latest 3.4-asan: ${latest34ASan}`)
           core.setOutput('should_build', latestReleaseCommit !== latestDevCommit)
           core.setOutput('previous_release', release.tag_name)
     - name: Compute build and reuse matrix

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
       with:
         repository: ruby/ruby
         path: ruby
-        fetch-depth: 0
     - name: Set latest_commit
       id: latest_commit
       working-directory: ruby
@@ -38,7 +37,9 @@ jobs:
       id: latest_commit_3_4_asan
       working-directory: ruby
       run: |
-        git checkout ruby_3_4
+        git fetch origin --no-tags '+refs/tags/v3_4_*:refs/tags/v3_4_*'
+        LATEST_TAG=$(git tag --list | grep -E "v3_4_[0-9]+$" | sort -V | tail -n1)
+        git checkout "$LATEST_TAG"
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
     - name: Check if latest commit already built
       uses: actions/github-script@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,14 +124,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: ruby/ruby
-        ref: ${{ needs.prepare.outputs.commit }}
-      if: matrix.name != '3.4-asan'
-    - name: Clone ruby (3.4-asan)
-      uses: actions/checkout@v4
-      with:
-        repository: ruby/ruby
-        ref: ${{ needs.prepare.outputs.commit_3_4_asan }}
-      if: matrix.name == '3.4-asan'
+        ref: ${{ matrix.name != '3.4-asan' && needs.prepare.outputs.commit || needs.prepare.outputs.commit_3_4_asan }}
     - name: Clone ruby-dev-builder
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       should_build: ${{ steps.check_commit.outputs.should_build }}
       commit: ${{ steps.latest_commit.outputs.commit }}
+      commit_3_4_asan: ${{ steps.latest_commit_3_4_asan.outputs.commit }}
       previous_release: ${{ steps.check_commit.outputs.previous_release }}
       build_matrix: ${{ steps.matrix.outputs.build_matrix }}
       reuse_matrix: ${{ steps.matrix.outputs.reuse_matrix }}
@@ -28,23 +29,31 @@ jobs:
       with:
         repository: ruby/ruby
         path: ruby
+        fetch-depth: 0
     - name: Set latest_commit
       id: latest_commit
       working-directory: ruby
       run: echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
+    - name: Set latest commit (3.4-asan)
+      id: latest_commit_3_4_asan
+      working-directory: ruby
+      run: |
+        git checkout ruby_3_4
+        echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
     - name: Check if latest commit already built
       uses: actions/github-script@v7
       id: check_commit
       with:
         script: |
           const latestDevCommit = "${{ steps.latest_commit.outputs.commit }}"
+          const latest34Asan = "${{ steps.latest_commit_3_4_asan.outputs.commit }}"
           const { owner, repo } = context.repo
           let { data: release } = await github.rest.repos.getLatestRelease({ owner, repo })
           const firstLine = release.body.split('\n')[0]
           const latestReleaseCommit = firstLine.split('@')[1]
           console.log(`Latest release commit: ${latestReleaseCommit}`)
           console.log(`Latest ruby commit: ${latestDevCommit}`)
+          console.log(`Latest 3.4-asan: ${latest34Asan}`)
           core.setOutput('should_build', latestReleaseCommit !== latestDevCommit)
           core.setOutput('previous_release', release.tag_name)
     - name: Compute build and reuse matrix
@@ -56,14 +65,14 @@ jobs:
           const skipSlow = "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_slow == 'true' }}"
           const buildMatrix = JSON.stringify(
             skipSlow === 'false' ?
-              { os: osList, name: ['head', 'debug'], include: [{ os: 'ubuntu-24.04', name: 'asan' }] } :
+              { os: osList, name: ['head', 'debug'], include: [{ os: 'ubuntu-24.04', name: 'asan' }, { os: 'ubuntu-24.04', name: '3.4-asan' }] } :
               { os: osList, name: ['head'] }
           )
           core.setOutput('build_matrix', buildMatrix)
           const reuseMatrix = JSON.stringify(
             skipSlow === 'false' ?
               { os: ['ubuntu-latest'], name: ['noop'] } : // GitHub doesn't like having an empty matrix, skips jobs that depend on reuse-slow
-              { os: osList, name: ['debug'], include: [{ os: 'ubuntu-24.04', name: 'asan' }] }
+              { os: osList, name: ['debug'], include: [{ os: 'ubuntu-24.04', name: 'asan' }, { os: 'ubuntu-24.04', name: '3.4-asan' }] }
           )
           core.setOutput('reuse_matrix', reuseMatrix)
           console.log(`build_matrix: ${buildMatrix}, reuse_matrix: ${reuseMatrix}`)
@@ -116,6 +125,13 @@ jobs:
       with:
         repository: ruby/ruby
         ref: ${{ needs.prepare.outputs.commit }}
+      if: matrix.name != '3.4-asan'
+    - name: Clone ruby (3.4-asan)
+      uses: actions/checkout@v4
+      with:
+        repository: ruby/ruby
+        ref: ${{ needs.prepare.outputs.commit_3_4_asan }}
+      if: matrix.name == '3.4-asan'
     - name: Clone ruby-dev-builder
       uses: actions/checkout@v4
       with:
@@ -191,7 +207,7 @@ jobs:
         # Make the test timeouts more generous too (ASAN is slower)
         echo "RUBY_TEST_TIMEOUT_SCALE=5" >> $GITHUB_ENV
         echo "SYNTAX_SUGGEST_TIMEOUT=600" >> $GITHUB_ENV
-      if: matrix.name == 'asan'
+      if: matrix.name == 'asan' || matrix.name == '3.4-asan'
 
     # Build
     - run: mkdir -p ~/.rubies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       id: latest_commit_3_4_asan
       working-directory: ruby
       run: |
-        git fetch origin --no-tags '+refs/tags/v3_4_*:refs/tags/v3_4_*'
+        git fetch origin --depth=1 --no-tags '+refs/tags/v3_4_*:refs/tags/v3_4_*'
         LATEST_TAG=$(git tag --list | grep -E "v3_4_[0-9]+$" | sort -V | tail -n1)
         git checkout "$LATEST_TAG"
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**What does this PR do?**

This PR is a second attempt at adding 3.4-asan builds (first attempt was https://github.com/ruby/ruby-dev-builder/pull/13); this version is now atop https://github.com/ruby/ruby-dev-builder/pull/14 .

It introduces a new "3.4-asan" build, based on the existing asan builds, but just pointed at the `ruby_3_4` branch.

In https://github.com/ruby/ruby-dev-builder/pull/13, we were building the latest tagged 3.4 release, which I expect would be more stable than just using `ruby_3_4` (and thus better for my downstream purposes of "having a build that doesn't fail for non-asan-related reasons").

Switching between both options is as simple as:

```diff
diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
index 7eb72a8..d7608d9 100644
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
       with:
         repository: ruby/ruby
         path: ruby
+        fetch-tags: true
         fetch-depth: 0
     - name: Set latest_commit
       id: latest_commit
       working-directory: ruby
@@ -37,7 +39,8 @@ jobs:
       id: latest_commit_3_4_asan
       working-directory: ruby
       run: |
-        git checkout ruby_3_4
+        LATEST_TAG=$(git tag --list | grep -E "v3_4_[0-9]+$" | sort -V | tail -n1)
+        git checkout "$LATEST_TAG"
         echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
     - name: Check if latest commit already built
       uses: actions/github-script@v7
```

I personally prefer building from the tag, but happy to use the branch option if that's preferrable.

**Motivation:**

The intention of "3.4-stable" is to provide the latest up-to-date stable Ruby, so that we can reliably use it as a breaking CI step.

As discussed in https://github.com/ruby/setup-ruby/issues/682, the current ruby-asan builds are a bit of a "sharp edge" when used in CI because they may break due to changes that are completely unrelated to asan.

Building asan rubies is a bit awkward still, as e.g. ruby-build and other version managers don't have support for it, and it requires very modern versions of specific system tools (e.g. clang).

**Additional Notes:**

In particular, I decided to not touch the logic that determines weather there's a more recent commit to build or not. This does mean that if ruby master sees no commits, but there's changes in the 3.4 branch, this won't be picked up immediately; and it also means that if there's a new master commit and no change to the 3.4 branch we still rebuild 3.4-asan.

My thinking is that given that #14 added caching already, this approach keeps things simple.

Let me know if you're not convinced, and I can change that.

**How to test the change?**

I've built this in the downstream fork, and manually downloaded the resulting Ruby and it seems to be in good shape and with asan working fine.

* Successful run: https://github.com/DataDog/ruby-dev-builder/actions/runs/13371638547
* Resulting builds: https://github.com/DataDog/ruby-dev-builder/releases/tag/v20250217.134317